### PR TITLE
Add function to find the longest subarray with zero sum

### DIFF
--- a/F) Array/Subarray/8.2.6Longest Subarray Zero Sum.cpp
+++ b/F) Array/Subarray/8.2.6Longest Subarray Zero Sum.cpp
@@ -1,0 +1,29 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int LongestSubsetWithZeroSum(vector<int> arr) {
+    int n = arr.size();
+    int cnt = 0;
+    int sum = 0;
+
+    unordered_map<int, int> map;
+    map[0] = -1;
+
+    for (int i = 0; i < n; i++) {
+        sum += arr[i];
+        if (map.find(sum) != map.end()) {
+            cnt = max(cnt, i - map[sum]);
+        } else {
+            map[sum] = i;
+        }
+    }
+    
+    return cnt;
+}
+
+int main() {
+    vector<int> arr = {6, 1, -1, 2, -1, 4, -5, -5};
+    cout << "Length of the longest subarray with zero sum: " 
+         << LongestSubsetWithZeroSum(arr) << endl;
+    return 0;
+}


### PR DESCRIPTION
This PR introduces a function LongestSubsetWithZeroSum that calculates the length of the longest subarray with a sum of zero in an input vector. The algorithm uses a hash map to optimize the time complexity, improving it from a brute-force solution to a more efficient O(n) approach.

Key Changes:
Implemented the LongestSubsetWithZeroSum function.
Optimized the subarray search using a prefix sum and hash map to track cumulative sums.
Added test cases in the main function to validate the logic with an example array.

Performance:
Time Complexity: O(n), where n is the size of the input array.
Space Complexity: O(n) due to the use of an unordered map for storing cumulative sums.

Testing:
Tested with example array: {6, 1, -1, 2, -1, 4, -5, -5}.
Verified that the output is correct, returning the length of the longest subarray with a sum of zero.

Fixes #60 